### PR TITLE
feat(api): Demo streaming to API

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -115,15 +115,15 @@ files = [
 
 [[package]]
 name = "faker"
-version = "21.0.0"
+version = "22.0.0"
 requires_python = ">=3.8"
 summary = "Faker is a Python package that generates fake data for you."
 dependencies = [
     "python-dateutil>=2.4",
 ]
 files = [
-    {file = "Faker-21.0.0-py3-none-any.whl", hash = "sha256:ff61cca42547795bee8a11319792a8fee6d0f0cd191e831f7f3050c5851fcd8a"},
-    {file = "Faker-21.0.0.tar.gz", hash = "sha256:2d8a350e952225a145307d7461881c44a1c9320e90fbe8bd903d5947f133f3ec"},
+    {file = "Faker-22.0.0-py3-none-any.whl", hash = "sha256:9c22c0a734ca01c6e4f2259eab5dab9081905a9d67b27272aea5c9feeb5a3789"},
+    {file = "Faker-22.0.0.tar.gz", hash = "sha256:1d5dc0a75da7bc40741ee4c84d99dc087b97bd086d4222ad06ac4dd2219bcf3f"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,6 @@ convention = "pep257"
 [tool.ruff]
 line-length = 120
 target-version = "py311"  # defaults to 3.8, but this repo targets 3.9%
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -18,6 +18,14 @@ class DemoSessionManager:
         os.makedirs(self.DEMOS_PATH, exist_ok=True)
 
     def make_or_get_file_handle(self, session_id: str) -> BinaryIO:
+        """Take in a session ID and create or return a file handle.
+
+        Args:
+            session_id: Session ID.
+
+        Returns:
+            File handle for the session_id
+        """
         if session_id not in self.file_handles:
             write_path = os.path.join(self.DEMOS_PATH, f"{session_id}.dem")
             self.file_handles[session_id] = open(write_path, "wb")
@@ -25,7 +33,11 @@ class DemoSessionManager:
         return self.file_handles[session_id]
 
     def handle_demo_data(self, data: dict[str, str | bytes | int]) -> None:
-        """Handle incoming data from a client upload."""
+        """Handle incoming data from a client upload.
+
+        Args:
+            data: dict of {session_id: ..., data: bytes or self.SENTINEL}
+        """
         session_id = str(data["session_id"])
 
         file_handle = self.make_or_get_file_handle(session_id)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -111,6 +111,10 @@ async def demo_session(data: dict[str, str | bytes | int]) -> dict[str, str]:
 
     Smart enough to know where to write data to based on the session ID
     as to handle reconnecting/duplicates.
+
+    Might want to implement something like
+    https://docs.litestar.dev/2/usage/websockets.html#class-based-websocket-handling
+    because it looks cleaner and likely can handle auth/accepting/valid session id better
     """
     demo_manager.handle_demo_data(data)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,7 +50,7 @@ def test_demo_streaming(mock_handle, demo_file_path, session_id, tmp_path) -> No
                     data = {"session_id": session_id, "data": encoded_chunk}
                     ws.send_json(data)
 
-    time.sleep(3)
+    time.sleep(3)  # wait for buffer to finish sinking
     with open(write_path, "rb") as actual:
         with open(demo_file_path, "rb") as expected:
             assert actual.read() == expected.read()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,26 +1,56 @@
+import base64
+import time
+from importlib.resources import files
 from unittest import mock
 
+import pytest
 from api.app import app
 from litestar.testing import TestClient
 
+from tests import data
+
+DEMO_CHUNKSIZE_BYTES = 1024
+
+
+@pytest.fixture
+def demo_file_path() -> str:
+    source = files(data).joinpath("test_demo.dem")
+    return str(source)
+
+
+@pytest.fixture
+def session_id() -> int:
+    return 123
+
 
 @mock.patch("api.app.generate_uuid4_int")
-def test_session_id(mock_uuid4) -> None:
+def test_session_id(mock_uuid4, session_id) -> None:
     with TestClient(app=app) as client:
-        mock_uuid4.return_value = 123
-        session_id = client.get("/session_id").json()
-        assert session_id["session_id"] == 123
+        mock_uuid4.return_value = session_id
+        api_session_id = client.get("/session_id").json()
+        assert api_session_id["session_id"] == session_id
 
 
-demo_data = {
-    "uploader_steamid": "foo",
-    "data": 123,
-}
-
-
-def test_health_check() -> None:
+@mock.patch("api.app.DemoSessionManager.make_or_get_file_handle")
+def test_demo_streaming(mock_handle, demo_file_path, session_id, tmp_path) -> None:
+    write_path = f"{tmp_path}.dem"
     with TestClient(app=app) as client:
+        mock_handle.return_value = open(write_path, "wb")
         ws_endpoint = client.websocket_connect("/demos")
-
         with ws_endpoint as ws:
-            ws.send_json(demo_data)
+            with open(demo_file_path, "rb") as f:
+                while True:
+                    chunk = f.read(DEMO_CHUNKSIZE_BYTES)
+                    if not chunk:
+                        data = {"session_id": session_id, "data": -1}
+                        ws.send_json(data)
+                        break
+
+                    encoded_chunk = base64.b64encode(chunk).decode("utf-8")
+                    data = {"session_id": session_id, "data": encoded_chunk}
+                    ws.send_json(data)
+
+    time.sleep(3)
+    with open(write_path, "rb") as actual:
+        with open(demo_file_path, "rb") as expected:
+            assert actual.read() == expected.read()


### PR DESCRIPTION
Pretty simple impl, might want to do https://docs.litestar.dev/2/usage/websockets.html#class-based-websocket-handling in the future to better handle starting sessions but will handle that once there is a DB we can talk to and check against as a source of truth for active sessions.

A file system like S3 impl will have to wait because I dont really know how that is gonna work until we know the hardware