### PR TITLE
Container creation script

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -14,4 +14,5 @@ RUN pdm sync --prod --no-editable
 
 EXPOSE 8000
 
-ENTRYPOINT pdm run app
+RUN touch /first_run
+ENTRYPOINT ["/bin/sh", "-c", "if [ -f /first_run ]; then pdm run alembic upgrade head; rm /first_run; fi; exec pdm run app"]

--- a/create.sh
+++ b/create.sh
@@ -1,0 +1,22 @@
+export STEAM_API_KEY=no
+export POSTGRES_USER=MEGASCATTERBOMB
+export POSTGRES_PASSWORD=masterbase
+export POSTGRES_HOST=172.20.1.10
+export POSTGRES_PORT=5432
+export API_HOST=172.20.1.20
+
+if [[ "$1" == "--replace" ]]; then
+    docker stop masterbase-db-dev masterbase-api-dev
+    docker rm masterbase-db-dev masterbase-api-dev
+    docker rmi db-dev api-dev
+    docker network rm masterbase-network-dev
+fi
+
+pdm sync -G:all
+docker network create --driver bridge masterbase-network-dev --subnet=172.20.0.0/16
+docker build -f Dockerfile.db . -t db-dev
+docker create --name masterbase-db-dev --network masterbase-network-dev --ip $POSTGRES_HOST -p 8050:5432 -e POSTGRES_USER=$POSTGRES_USER -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -e POSTGRES_DB=demos -t db-dev
+docker start masterbase-db-dev
+docker build -f Dockerfile.api . -t api-dev
+docker create --name masterbase-api-dev --network masterbase-network-dev --ip $API_HOST -p 8000:8000 -e POSTGRES_USER=$POSTGRES_USER -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -e POSTGRES_HOST=$POSTGRES_HOST -e POSTGRES_PORT=$POSTGRES_PORT -t api-dev
+docker start masterbase-api-dev


### PR DESCRIPTION
Adds a bash script `create.sh` which handles the initial creation and setup of the docker network and containers.

Includes some default placeholder values.

For convenience, the script can be run with `--replace` so that old containers/networks with the same names are nuked prior to the new containers being set up.

This PR also moves the alembic upgrade to the api dockerfile. Kinda sketch since we have to assume the db container is also running but the script should reduce the likelihood of mistakes.